### PR TITLE
Change type GraphRequestProtocol.apiVersion from String to concrete GraphAPIVersion.

### DIFF
--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		810192CC1D013FC100B9E881 /* GraphRequestProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192CB1D013FC100B9E881 /* GraphRequestProtocol.swift */; };
 		810192CE1D01409400B9E881 /* GraphResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192CD1D01409400B9E881 /* GraphResponse.swift */; };
 		810192D01D0145AE00B9E881 /* GraphResponseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192CF1D0145AE00B9E881 /* GraphResponseProtocol.swift */; };
+		8110E62F1D46A0AA00C349B4 /* GraphAPIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8110E62E1D46A0AA00C349B4 /* GraphAPIVersion.swift */; };
 		811C5E4D1CFFD4D100E4A925 /* FacebookCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8115C0D81CFE540D001FF33B /* FacebookCore.framework */; };
 		811C5E561CFFD4F800E4A925 /* FacebookCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8115C0D81CFE540D001FF33B /* FacebookCore.framework */; };
 		811C5E771CFFD5DD00E4A925 /* Dictionary+KeyValueMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811C5E751CFFD5DD00E4A925 /* Dictionary+KeyValueMap.swift */; };
@@ -355,6 +356,7 @@
 		810192CB1D013FC100B9E881 /* GraphRequestProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphRequestProtocol.swift; sourceTree = "<group>"; };
 		810192CD1D01409400B9E881 /* GraphResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphResponse.swift; sourceTree = "<group>"; };
 		810192CF1D0145AE00B9E881 /* GraphResponseProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphResponseProtocol.swift; sourceTree = "<group>"; };
+		8110E62E1D46A0AA00C349B4 /* GraphAPIVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphAPIVersion.swift; sourceTree = "<group>"; };
 		8115C0D81CFE540D001FF33B /* FacebookCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FacebookCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8115C0E41CFE543A001FF33B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		811AD1B51D35D9C8007689DC /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 				810192CF1D0145AE00B9E881 /* GraphResponseProtocol.swift */,
 				810192C71D01380600B9E881 /* GraphRequestConnection.swift */,
 				810192C91D0139CF00B9E881 /* GraphRequestConnection.Delegate.swift */,
+				8110E62E1D46A0AA00C349B4 /* GraphAPIVersion.swift */,
 			);
 			path = GraphRequest;
 			sourceTree = "<group>";
@@ -1284,6 +1287,7 @@
 				810192B11D01305400B9E881 /* AppEventParameterName.swift in Sources */,
 				811C5E771CFFD5DD00E4A925 /* Dictionary+KeyValueMap.swift in Sources */,
 				810192B21D01305400B9E881 /* AppEventsLogger.FlushBehavior.swift in Sources */,
+				8110E62F1D46A0AA00C349B4 /* GraphAPIVersion.swift in Sources */,
 				817A0A0E1D07CE8A00FD423A /* GraphRequestResult.swift in Sources */,
 				810192AE1D01305400B9E881 /* AppEvent.Builtin.swift in Sources */,
 				810192AF1D01305400B9E881 /* AppEvent.swift in Sources */,

--- a/Samples/Catalog/Sources/GraphAPIReadViewController.swift
+++ b/Samples/Catalog/Sources/GraphAPIReadViewController.swift
@@ -22,7 +22,8 @@ import UIKit
 import FacebookCore
 
 class GraphAPIReadViewController: UITableViewController {
-  func presentAlertControllerFor(result: GraphRequestResult<GraphRequest>) {
+
+  func presentAlertControllerFor<P: GraphRequestProtocol>(result: GraphRequestResult<P>) {
     let alertController: UIAlertController
     switch result {
     case .Success(let response):
@@ -40,17 +41,26 @@ class GraphAPIReadViewController: UITableViewController {
 // MARK: - Read Profile
 //--------------------------------------
 
+struct FBProfileRequest: GraphRequestProtocol {
+  typealias Response = GraphResponse
+
+  var graphPath: String = "/me"
+  var parameters: [String : AnyObject]? = ["fields": "id, name"]
+  var accessToken: AccessToken? = AccessToken.current
+  var httpMethod: GraphRequestHTTPMethod = .GET
+  var apiVersion: GraphAPIVersion = 2.7
+}
+
 extension GraphAPIReadViewController {
   /**
    Fetches the currently logged in user's public profile.
+   Uses a custom type for profile request.
 
    See https://developers.facebook.com/docs/graph-api/reference/user/ for details.
    */
   @IBAction func readProfile() {
-    let request = GraphRequest(graphPath: "/me",
-                               parameters: [ "fields" : "id, name" ],
-                               httpMethod: .GET)
-    request.start { httpResponse, result in
+    let request = FBProfileRequest()
+    request.start { (httpResponse, result) in
       switch result {
       case .Success(let response):
         print("Graph Request Succeeded: \(response)")

--- a/Sources/Core/GraphRequest/GraphAPIVersion.swift
+++ b/Sources/Core/GraphRequest/GraphAPIVersion.swift
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+
+import FBSDKCoreKit
+
+/**
+ Represents version of the Facebook Graph API.
+
+ To find out the current latest version - refer to https://developers.facebook.com/docs/graph-api/overview
+ */
+public struct GraphAPIVersion {
+  /// String representation of an api version.
+  public let stringValue: String
+}
+
+extension GraphAPIVersion {
+
+  /**
+   Represents the default Graph API version.
+   Note: This value may change between versions of the SDK.
+   */
+  public static let Default: GraphAPIVersion = {
+    var version = FBSDK_TARGET_PLATFORM_VERSION
+    // ObjC SDK has a prefix of `v` on this constant
+    if version.hasPrefix("v") {
+      version = String(version.characters.dropFirst())
+    }
+    return GraphAPIVersion(stringLiteral: version)
+  }()
+}
+
+extension GraphAPIVersion: StringLiteralConvertible {
+
+  /**
+   Create a `GraphAPIVersion` from a string literal.
+
+   - parameter value: The string literal to create from.
+   */
+  public init(stringLiteral value: StringLiteralType) {
+    stringValue = value
+  }
+
+  /**
+   Create a `GraphAPIVersion` from a unicode scalar literal.
+
+   - parameter value: The string literal to create from.
+   */
+  public init(unicodeScalarLiteral value: String) {
+    self.init(stringLiteral: value)
+  }
+
+  /**
+   Create a `GraphAPIVersion` from an extended grapheme cluster.
+
+   - parameter value: The string literal to create from.
+   */
+  public init(extendedGraphemeClusterLiteral value: String) {
+    self.init(stringLiteral: value)
+  }
+}
+
+extension GraphAPIVersion: FloatLiteralConvertible {
+
+  /**
+   Create a `GraphAPIVersion` from a float literal.
+
+   - parameter value: The float literal to create from.
+   */
+  public init(floatLiteral value: FloatLiteralType) {
+    stringValue = String(format: "%.1f", value)
+  }
+}

--- a/Sources/Core/GraphRequest/GraphRequest.swift
+++ b/Sources/Core/GraphRequest/GraphRequest.swift
@@ -45,8 +45,8 @@ public struct GraphRequest: GraphRequestProtocol {
   /// The `HTTPMethod` to use for the request, e.g. `.GET`/`.POST`/`.DELETE`.
   public let httpMethod: GraphRequestHTTPMethod
 
-  /// Graph API Version to use, e.g. `"2.7"`.
-  public let apiVersion: String
+  /// Graph API Version to use, e.g. `"2.7"`. Default: `GraphRequestDefaultAPIVersion`.
+  public let apiVersion: GraphAPIVersion
 
   /**
    Initializes a new instance of graph request.
@@ -55,13 +55,13 @@ public struct GraphRequest: GraphRequestProtocol {
    - parameter parameters:  Optional parameters dictionary.
    - parameter accessToken: Optional authentication token to use. Defaults to `AccessToken.current`.
    - parameter httpMethod:  Optional `GraphRequestHTTPMethod` to use for the request. Defaults to `.GET`.
-   - parameter apiVersion:  Optional Graph API version to use. Defaults to `FBSDK_TARGET_PLATFORM_VERSION`.
+   - parameter apiVersion:  Optional Graph API version to use. Defaults to `GraphAPIVersion.Default`.
    */
   public init(graphPath: String,
               parameters: [String : AnyObject] = [:],
               accessToken: AccessToken? = AccessToken.current,
               httpMethod: GraphRequestHTTPMethod = .GET,
-              apiVersion: String = FBSDK_TARGET_PLATFORM_VERSION) {
+              apiVersion: GraphAPIVersion = .Default) {
     self.graphPath = graphPath
     self.parameters = parameters
     self.accessToken = accessToken

--- a/Sources/Core/GraphRequest/GraphRequestProtocol.Bridge.swift
+++ b/Sources/Core/GraphRequest/GraphRequestProtocol.Bridge.swift
@@ -28,6 +28,9 @@ extension GraphRequestProtocol {
       }
       return (key, value)
     })
+
+    // ObjC SDK requires `v` as a prefix for the Graph API Version.
+    let apiVersion = "v" + self.apiVersion.stringValue
     return FBSDKGraphRequest(graphPath: graphPath,
                              parameters: sdkParameters,
                              tokenString: accessToken?.authenticationToken,

--- a/Sources/Core/GraphRequest/GraphRequestProtocol.swift
+++ b/Sources/Core/GraphRequest/GraphRequestProtocol.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+import FBSDKCoreKit
+
 /**
  Protocol that represents a request to the Facebook Graph API.
 
@@ -47,8 +49,8 @@ public protocol GraphRequestProtocol {
   /// The `HTTPMethod` to use for the request, e.g. `.GET`/`.POST`/`.DELETE`.
   var httpMethod: GraphRequestHTTPMethod { get }
 
-  /// Graph API Version to use, e.g. `"2.7"`.
-  var apiVersion: String { get }
+  /// Graph API Version to use. Default: `GraphAPIVersion.Default`.
+  var apiVersion: GraphAPIVersion { get }
 }
 
 extension GraphRequestProtocol {


### PR DESCRIPTION
The new type is both string and float literal convertible.
Also fix the dichotomy in ObjC SDK that requires `v` prefix for the apiVersion (the swift one shouldn't).

Fixes #28