### PR TITLE
Rename ApplicationDelegate to SDKApplicationDelegate to avoid name clashes.

### DIFF
--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		810192B21D01305400B9E881 /* AppEventsLogger.FlushBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192A71D01305400B9E881 /* AppEventsLogger.FlushBehavior.swift */; };
 		810192B31D01305400B9E881 /* AppEventsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192A81D01305400B9E881 /* AppEventsLogger.swift */; };
 		810192B41D01305400B9E881 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192AA1D01305400B9E881 /* AccessToken.swift */; };
-		810192B51D01305400B9E881 /* ApplicationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192AB1D01305400B9E881 /* ApplicationDelegate.swift */; };
+		810192B51D01305400B9E881 /* SDKApplicationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192AB1D01305400B9E881 /* SDKApplicationDelegate.swift */; };
 		810192B61D01305400B9E881 /* SDKLoggingBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192AC1D01305400B9E881 /* SDKLoggingBehavior.swift */; };
 		810192B71D01305400B9E881 /* SDKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192AD1D01305400B9E881 /* SDKSettings.swift */; };
 		810192C41D0130C500B9E881 /* GraphRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810192C31D0130C500B9E881 /* GraphRequest.swift */; };
@@ -348,7 +348,7 @@
 		810192A71D01305400B9E881 /* AppEventsLogger.FlushBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppEventsLogger.FlushBehavior.swift; sourceTree = "<group>"; };
 		810192A81D01305400B9E881 /* AppEventsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppEventsLogger.swift; sourceTree = "<group>"; };
 		810192AA1D01305400B9E881 /* AccessToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessToken.swift; sourceTree = "<group>"; };
-		810192AB1D01305400B9E881 /* ApplicationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationDelegate.swift; sourceTree = "<group>"; };
+		810192AB1D01305400B9E881 /* SDKApplicationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKApplicationDelegate.swift; sourceTree = "<group>"; };
 		810192AC1D01305400B9E881 /* SDKLoggingBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKLoggingBehavior.swift; sourceTree = "<group>"; };
 		810192AD1D01305400B9E881 /* SDKSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKSettings.swift; sourceTree = "<group>"; };
 		810192C31D0130C500B9E881 /* GraphRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphRequest.swift; sourceTree = "<group>"; };
@@ -499,7 +499,7 @@
 			isa = PBXGroup;
 			children = (
 				810192AA1D01305400B9E881 /* AccessToken.swift */,
-				810192AB1D01305400B9E881 /* ApplicationDelegate.swift */,
+				810192AB1D01305400B9E881 /* SDKApplicationDelegate.swift */,
 				810192AC1D01305400B9E881 /* SDKLoggingBehavior.swift */,
 				810192AD1D01305400B9E881 /* SDKSettings.swift */,
 			);
@@ -1279,7 +1279,7 @@
 				817021AE1D18DE1500ECE7AC /* UserProfile.PictureView.swift in Sources */,
 				810192B61D01305400B9E881 /* SDKLoggingBehavior.swift in Sources */,
 				81FC4CBB1D0674F4003F3A46 /* PublishPermission.swift in Sources */,
-				810192B51D01305400B9E881 /* ApplicationDelegate.swift in Sources */,
+				810192B51D01305400B9E881 /* SDKApplicationDelegate.swift in Sources */,
 				810192C81D01380600B9E881 /* GraphRequestConnection.swift in Sources */,
 				810192C41D0130C500B9E881 /* GraphRequest.swift in Sources */,
 				810192B01D01305400B9E881 /* AppEventName.swift in Sources */,

--- a/Samples/Catalog/Sources/AppDelegate.swift
+++ b/Samples/Catalog/Sources/AppDelegate.swift
@@ -28,16 +28,16 @@ final class AppDelegate: UIResponder {
 
 extension AppDelegate: UIApplicationDelegate {
   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-    ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+    SDKApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
 
     return true
   }
 
   func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject) -> Bool {
-    return ApplicationDelegate.shared.application(application,
-                                                  openURL: url,
-                                                  sourceApplication: sourceApplication,
-                                                  annotation: annotation)
+    return SDKApplicationDelegate.shared.application(application,
+                                                     openURL: url,
+                                                     sourceApplication: sourceApplication,
+                                                     annotation: annotation)
   }
 
   func applicationDidBecomeActive(application: UIApplication) {

--- a/Sources/Core/Common/SDKApplicationDelegate.swift
+++ b/Sources/Core/Common/SDKApplicationDelegate.swift
@@ -21,22 +21,22 @@ import UIKit
 import FBSDKCoreKit
 
 /**
- The ApplicationDelegate is designed to post process the results from Facebook Login or Facebook Dialogs
+ The `SDKApplicationDelegate` is designed to post process the results from Facebook Login or Facebook Dialogs
  (or any action that requires switching over to the native Facebook app or Safari).
 
  The methods in this class are designed to mirror those in UIApplicationDelegate, and you
  should call them in the respective methods in your AppDelegate implementation.
  */
-public final class ApplicationDelegate {
+public final class SDKApplicationDelegate {
   private let delegate: FBSDKApplicationDelegate = FBSDKApplicationDelegate.sharedInstance()
 
   /// Returns the singleton instance of an application delegate.
-  public static let shared = ApplicationDelegate()
+  public static let shared = SDKApplicationDelegate()
 
   private init() { }
 }
 
-extension ApplicationDelegate {
+extension SDKApplicationDelegate {
   /**
    Call this function from the `UIApplicationDelegate.application(application:didFinishLaunchingWithOptions:)` function
    of the AppDelegate of your app It should be invoked for the proper initialization of the Facebook SDK.


### PR DESCRIPTION
Preventing name clashes, as `ApplicationDelegate` is likely to exist in the app module.

Closes #35