### PR TITLE
Update Facebook ObjC SDK dependency to 4.16.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "facebook/facebook-ios-sdk" ~> 4.14
+github "facebook/facebook-ios-sdk" ~> 4.16

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "BoltsFramework/Bolts-ObjC" "1.8.4"
-github "facebook/facebook-ios-sdk" "sdk-version-4.15.0"
+github "facebook/facebook-ios-sdk" "sdk-version-4.16.0"

--- a/FacebookCore.podspec
+++ b/FacebookCore.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'ENABLE_TESTABILITY' => 'YES' }
 
   s.ios.dependency 'Bolts', '~> 1.8'
-  s.ios.dependency 'FBSDKCoreKit', '~> 4.15'
+  s.ios.dependency 'FBSDKCoreKit', '~> 4.16'
 end

--- a/FacebookLogin.podspec
+++ b/FacebookLogin.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.ios.dependency 'FacebookCore', '~> 0.2'
   s.ios.dependency 'Bolts', '~> 1.8'
-  s.ios.dependency 'FBSDKCoreKit', '~> 4.15'
-  s.ios.dependency 'FBSDKLoginKit', '~> 4.15'
+  s.ios.dependency 'FBSDKCoreKit', '~> 4.16'
+  s.ios.dependency 'FBSDKLoginKit', '~> 4.16'
 end

--- a/FacebookShare.podspec
+++ b/FacebookShare.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
 
   s.ios.dependency 'FacebookCore', '~> 0.2'
   s.ios.dependency 'Bolts', '~> 1.8'
-  s.ios.dependency 'FBSDKCoreKit', '~> 4.15'
-  s.ios.dependency 'FBSDKShareKit', '~> 4.15'
+  s.ios.dependency 'FBSDKCoreKit', '~> 4.16'
+  s.ios.dependency 'FBSDKShareKit', '~> 4.16'
 end


### PR DESCRIPTION
Update dependency everywhere.
Tested by running some basic scenarios via SwiftCatalog app.
