### PR TITLE
Improve ambiguous `logIn()` function names in LoginManager.

### DIFF
--- a/Samples/Catalog/Sources/LoginManagerViewController.swift
+++ b/Samples/Catalog/Sources/LoginManagerViewController.swift
@@ -43,14 +43,14 @@ extension LoginManagerViewController {
 
   @IBAction func loginWithReadPermissions() {
     let loginManager = LoginManager()
-    loginManager.logIn([.publicProfile, .userFriends], viewController: self) { result in
+    loginManager.logIn(readPermissions: [.publicProfile, .userFriends], viewController: self) { result in
       self.loginManagerDidComplete(result)
     }
   }
 
   @IBAction func loginWithPublishPermissions() {
     let loginManager = LoginManager()
-    loginManager.logIn([.publishActions], viewController: self) { result in
+    loginManager.logIn(publishPermissions: [.publishActions], viewController: self) { result in
       self.loginManagerDidComplete(result)
     }
   }

--- a/Sources/Login/LoginManager.swift
+++ b/Sources/Login/LoginManager.swift
@@ -75,10 +75,10 @@ public final class LoginManager {
    - parameter viewController: Optional view controller to present from. Default: topmost view controller.
    - parameter completion:     Optional callback.
    */
-  public func logIn(_ permissions: [ReadPermission] = [.publicProfile],
+  public func logIn(readPermissions: [ReadPermission] = [.publicProfile],
                     viewController: UIViewController? = nil,
                     completion: ((LoginResult) -> Void)? = nil) {
-    let sdkPermissions = permissions.map({ $0.permissionValue.name })
+    let sdkPermissions = readPermissions.map({ $0.permissionValue.name })
     sdkManager.logIn(withReadPermissions: sdkPermissions,
                      from: viewController,
                      handler: LoginManager.sdkCompletionFor(completion))
@@ -98,10 +98,10 @@ public final class LoginManager {
    - parameter viewController: Optional view controller to present from. Default: topmost view controller.
    - parameter completion:     Optional callback.
    */
-  public func logIn(_ permissions: [PublishPermission] = [.publishActions],
+  public func logIn(publishPermissions: [PublishPermission] = [.publishActions],
                     viewController: UIViewController? = nil,
                     completion: ((LoginResult) -> Void)? = nil) {
-    let sdkPermissions = permissions.map({ $0.permissionValue.name })
+    let sdkPermissions = publishPermissions.map({ $0.permissionValue.name })
     sdkManager.logIn(withPublishPermissions: sdkPermissions,
                      from: viewController,
                      handler: LoginManager.sdkCompletionFor(completion))


### PR DESCRIPTION
Closes #95.