### PR TITLE
Fix swift compiler error base on FBSDKShareKit (4.23.0) #157

### DIFF
--- a/Sources/Share/Content/Link/LinkShareContent.swift
+++ b/Sources/Share/Content/Link/LinkShareContent.swift
@@ -118,9 +118,6 @@ extension LinkShareContent: Equatable {
 extension LinkShareContent: SDKBridgedContent {
   internal var sdkSharingContentRepresentation: FBSDKSharingContent {
     let content = FBSDKShareLinkContent()
-    content.contentDescription = self.description
-    content.contentTitle = self.title
-    content.imageURL = self.imageURL
     content.quote = self.quote
     content.contentURL = self.url
     content.hashtag = self.hashtag?.sdkHashtagRepresentation

--- a/Sources/Share/Content/Link/LinkShareContent.swift
+++ b/Sources/Share/Content/Link/LinkShareContent.swift
@@ -29,7 +29,11 @@ public struct LinkShareContent: ContentProtocol {
    The title to display for this link.
 
    This value may be discarded for specially handled links (ex: iTunes URLs).
+   
+   @deprecated `title` is deprecated from Graph API 2.9.
+   For more information, see https://developers.facebook.com/docs/apps/changelog#v2_9_deprecations.
    */
+  @available(*, deprecated, message: "`title` is deprecated from Graph API 2.9")
   public var title: String?
 
   /**
@@ -37,7 +41,11 @@ public struct LinkShareContent: ContentProtocol {
 
    If not specified, this field is automatically populated by information scraped from the contentURL,
    typically the title of the page. This value may be discarded for specially handled links (ex: iTunes URLs).
+   
+   @deprecated `description` is deprecated from Graph API 2.9.
+   For more information, see https://developers.facebook.com/docs/apps/changelog#v2_9_deprecations
    */
+  @available(*, deprecated, message: "`description` is deprecated from Graph API 2.9")
   public var description: String?
 
   /**
@@ -47,7 +55,13 @@ public struct LinkShareContent: ContentProtocol {
    */
   public var quote: String?
 
-  /// The URL of a picture to attach to this content.
+  /**
+   The URL of a picture to attach to this content.
+   
+   @deprecated `imageURL` is deprecated from Graph API 2.9.
+   For more information, see https://developers.facebook.com/docs/apps/changelog#v2_9_deprecations
+   */
+  @available(*, deprecated, message: "`imageURL` is deprecated from Graph API 2.9")
   public var imageURL: URL?
 
   /**


### PR DESCRIPTION
- The deprecated API has been deleted.
- Add deprecated API to `LinkShareContent` 