### PR TITLE
Update GraphAPIVersion.swift for Swift 4

### DIFF
--- a/Sources/Core/GraphRequest/GraphAPIVersion.swift
+++ b/Sources/Core/GraphRequest/GraphAPIVersion.swift
@@ -37,7 +37,7 @@ public struct GraphAPIVersion {
     var version = FBSDK_TARGET_PLATFORM_VERSION
     // ObjC SDK has a prefix of `v` on this constant
     if version.hasPrefix("v") {
-      version = String(version.characters.dropFirst())
+      version = String(version.dropFirst())
     }
     return GraphAPIVersion(stringLiteral: version)
   }()


### PR DESCRIPTION
Silent warning "'characters' is deprecated: Please use String or Substring directly" at Line 40