### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # Contributing to Facebook Swift SDK
 We want to make contributing to this project as easy and transparent as possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Pull Requests
 We actively welcome your pull requests.
 


### PR DESCRIPTION
**what is the change?:**
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [Facebook Swift SDK's Community Profile](https://github.com/facebook/facebook-sdk-swift/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1515" alt="screen shot 2018-01-11 at 7 10 50 am" src="https://user-images.githubusercontent.com/1114467/34832407-b6d5a112-f69e-11e7-833d-a0d1c2d43381.png">
<img width="1503" alt="screen shot 2018-01-11 at 7 11 01 am" src="https://user-images.githubusercontent.com/1114467/34832409-b6f19d9a-f69e-11e7-88d8-afc6e16557e8.png">

**issue:**
internal task t23481323