### PR TITLE
Fix documentation_url's in podspec files

### DIFF
--- a/FacebookCore.podspec
+++ b/FacebookCore.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version      = '0.3.0'
   s.author       = 'Facebook'
   s.homepage     = 'https://developers.facebook.com/docs/swift'
-  s.documentation_url = 'https://developers.facebook.com/docs/swift/reference'
+  s.documentation_url = 'https://developers.facebook.com/docs/swift/sdk-reference'
   s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
 
   s.summary      = "Official Facebook SDK in Swift to access Facebook Platform's core features."

--- a/FacebookLogin.podspec
+++ b/FacebookLogin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version      = '0.3.0'
   s.author       = 'Facebook'
   s.homepage     = 'https://developers.facebook.com/docs/swift'
-  s.documentation_url = 'https://developers.facebook.com/docs/swift/reference'
+  s.documentation_url = 'https://developers.facebook.com/docs/swift/sdk-reference'
   s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
 
   s.summary      = "Official Facebook SDK in Swift to integrate with Facebook Login."

--- a/FacebookShare.podspec
+++ b/FacebookShare.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version      = '0.3.0'
   s.author       = 'Facebook'
   s.homepage     = 'https://developers.facebook.com/docs/swift'
-  s.documentation_url = 'https://developers.facebook.com/docs/swift/reference'
+  s.documentation_url = 'https://developers.facebook.com/docs/swift/sdk-reference'
   s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
 
   s.summary      = "Official Facebook SDK in Swift to access Facebook Platform's Sharing Features."


### PR DESCRIPTION
Documentation URLs changed a while ago (template changes in appledoc and
xcconfig changes when targeting iOS 11). Fixing the URLs in podfiles silences warning
messages from cocoapods pod lib linter and resolves Travis CI test errors triggered by them (not
to mention actually fixing URLs for SDK docs here and there)