### PR TITLE
Changed deprecated function of Array from flatMap to CompactMap to make Swift 4.2 compilable

### DIFF
--- a/Sources/Core/Common/SDKSettings.swift
+++ b/Sources/Core/Common/SDKSettings.swift
@@ -142,12 +142,24 @@ extension SDKSettings {
    */
   public static var enabledLoggingBehaviors: Set<SDKLoggingBehavior> {
     get {
-      let behaviors = FBSDKSettings.loggingBehavior().flatMap { object -> SDKLoggingBehavior? in
+      let behaviors: [SDKLoggingBehavior]
+      
+      #if swift(>=4.1)
+      behaviors = FBSDKSettings.loggingBehavior().compactMap { object -> SDKLoggingBehavior? in
         if let value = object as? String {
           return SDKLoggingBehavior(sdkStringValue: value)
         }
         return nil
       }
+      #else
+      behaviors = FBSDKSettings.loggingBehavior().flatMap { object -> SDKLoggingBehavior? in
+        if let value = object as? String {
+          return SDKLoggingBehavior(sdkStringValue: value)
+        }
+        return nil
+      }
+      #endif
+      
       return Set(behaviors)
     }
     set {


### PR DESCRIPTION
`Array.flatMap` was deprecated in Swift 4.1 and it caused compile error on Swift 4.2 because it will translate as `Optional.flatMap` instead.