### PR TITLE
XCode 10 - Update flatMap to compactMap as deprecated

### DIFF
--- a/Sources/Core/Common/SDKSettings.swift
+++ b/Sources/Core/Common/SDKSettings.swift
@@ -142,12 +142,19 @@ extension SDKSettings {
    */
   public static var enabledLoggingBehaviors: Set<SDKLoggingBehavior> {
     get {
-      let behaviors = FBSDKSettings.loggingBehavior().flatMap { object -> SDKLoggingBehavior? in
+      let createBehavior = { (object: AnyHashable) -> SDKLoggingBehavior? in
         if let value = object as? String {
           return SDKLoggingBehavior(sdkStringValue: value)
         }
         return nil
       }
+
+#if swift(>=4.1)
+      let behaviors = FBSDKSettings.loggingBehavior().compactMap(createBehavior)
+#else
+      let behaviors = FBSDKSettings.loggingBehavior().flatMap(createBehavior)
+#endif
+
       return Set(behaviors)
     }
     set {


### PR DESCRIPTION
In Xcode 10 Line 151 has this compiler error: Argument type 'SDKLoggingBehavior?' does not conform to expected type 'Sequence'

Update flatMap which was was deprecated in Swift 4.1 and use CompactMap

closes #235 