### PR TITLE
Fix GraphRequestConnection some function are inaccessible for Xcode 10

### DIFF
--- a/Sources/Core/GraphRequest/GraphRequestConnection.swift
+++ b/Sources/Core/GraphRequest/GraphRequestConnection.swift
@@ -88,7 +88,7 @@ public class GraphRequestConnection {
    As described in [Graph API Batch Requests](https://developers.facebook.com/docs/reference/api/batch/).
    - parameter completion: Optional completion closure that is going to be called when the connection finishes or fails.
    */
-  func add<T>(_ request: T,
+  public func add<T>(_ request: T,
               batchEntryName: String? = nil,
               completion: Completion<T>? = nil) {
     let batchParameters = batchEntryName.map { ["name": $0] }
@@ -104,7 +104,7 @@ public class GraphRequestConnection {
    Examples include "depends_on", "name", or "omit_response_on_success".
    - parameter completion: Optional completion closure that is going to be called when the connection finishes or fails.
    */
-  func add<T>(_ request: T,
+  public func add<T>(_ request: T,
               batchParameters: [String: Any]?,
               completion: Completion<T>? = nil) {
     sdkConnection.add(request.sdkRequest,
@@ -116,7 +116,7 @@ public class GraphRequestConnection {
    Starts a connection with the server and sends all the requests in this connection.
    - warning: This method can't be called twice per a single `GraphRequestConnection` instance.
    */
-  func start() {
+  public func start() {
     sdkConnection.start()
   }
 
@@ -128,7 +128,7 @@ public class GraphRequestConnection {
    It does promise that all handlers will complete before the cancel returns.
    A call to `cancel` prior to a start implies a cancellation of all requests associated with the connection.
    */
-  func cancel() {
+  public func cancel() {
     sdkConnection.cancel()
   }
 


### PR DESCRIPTION
due to 'internal' protection level

For Xcode 10

# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass
- [x] I've ensured that my code lints properly
  - [x] I've run: `swiftlint` & `swiftlint autocorrect --format`
- [x] I've added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary)
- [x] I've updated the [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request
