### PR TITLE
Fix for callback problem

### DIFF
--- a/Sources/Share/Dialogs/ShareDialog/ShareDialog.swift
+++ b/Sources/Share/Dialogs/ShareDialog/ShareDialog.swift
@@ -21,7 +21,7 @@ import FBSDKShareKit
 /// A dialog for sharing content on Facebook.
 public final class ShareDialog<Content: ContentProtocol>: ContentSharingProtocol, ContentSharingDialogProtocol {
   private let sdkSharer: FBSDKShareDialog
-  private weak var sdkShareDelegate: SDKSharingDelegateBridge<Content>?
+  private var sdkShareDelegate: SDKSharingDelegateBridge<Content>?
 
   /**
    A `UIViewController` to present the dialog from.


### PR DESCRIPTION
weak definition is making problem when you want to use callbacks

# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

The weak definition is making a problem (delegate always nil) when you want to use callback.
