### PR TITLE
Add content to AppEventParameterName

### DIFF
--- a/Sources/Core/AppEvents/AppEventParameterName.swift
+++ b/Sources/Core/AppEvents/AppEventParameterName.swift
@@ -22,6 +22,8 @@ import FBSDKCoreKit.FBSDKAppEvents
  Represents a parameter name of the Facebook Analytics application event.
  */
 public enum AppEventParameterName: Hashable, RawRepresentable, ExpressibleByStringLiteral, CustomStringConvertible {
+  /// Data for the one or more pieces of content being logged about.
+  case content
   /// Identifier for the specific piece of content.
   case contentId
   /// Type of the content, e.g. "music"/"photo"/"video".
@@ -70,6 +72,7 @@ public enum AppEventParameterName: Hashable, RawRepresentable, ExpressibleByStri
   /// The corresponding `String` value.
   public var rawValue: String {
     switch self {
+    case .content: return FBSDKAppEventParameterNameContent
     case .contentId: return FBSDKAppEventParameterNameContentID
     case .contentType: return FBSDKAppEventParameterNameContentType
     case .currency: return FBSDKAppEventParameterNameCurrency


### PR DESCRIPTION
updated the facebook-ios-sdk submodule to the latest version
added content to AppEventParameterName which was already mentioned in facebook swift sdk documentation

# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This adds a new enum value content to AppEventParameterName to expose FBSDKAppEventParameterNameContent.

Fixes #241 