### PR TITLE
Fixing the AppEvent creator functions to match the documentation

### DIFF
--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -193,6 +193,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional content type.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter currency: Optional string representation of currency.
    - parameter valueToSum: Optional value to sum.
    - parameter extraParameters: Optional dictionary of extra parameters.
@@ -201,12 +202,14 @@ public extension AppEvent {
    */
   static func addedToWishlist(contentType: String? = nil,
                               contentId: String? = nil,
+                              contentData: String? = nil,
                               currency: String? = nil,
                               valueToSum: Double? = nil,
                               extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     currency.onSome { parameters[.currency] = $0 }
     return AppEvent(name: .addedToWishlist, parameters: parameters, valueToSum: valueToSum)
   }

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -311,6 +311,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional content type.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter valueToSum: Optional value to sum.
    - parameter extraParameters: Optional dictionary of extra parameters.
 
@@ -318,11 +319,13 @@ public extension AppEvent {
    */
   static func spentCredits(contentType: String? = nil,
                            contentId: String? = nil,
+                           contentData: String? = nil,
                            valueToSum: Double? = nil,
                            extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     return AppEvent(name: .spentCredits, parameters: parameters, valueToSum: valueToSum)
   }
 }

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -117,6 +117,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional type of the content.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter maxRatingValue: Optional max rating value.
    - parameter valueToSum: Optional value to sum.
    - parameter extraParameters: Optional dictionary of extra parameters.
@@ -125,12 +126,14 @@ public extension AppEvent {
    */
   static func rated<T: UnsignedInteger>(contentType: String? = nil,
                                         contentId: String? = nil,
+                                        contentData: String? = nil,
                                         maxRatingValue: T? = nil,
                                         valueToSum: Double? = nil,
                                         extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     maxRatingValue.onSome { parameters[.maxRatingValue] = NSNumber(value: UInt64($0)) }
     return AppEvent(name: .rated, parameters: parameters, valueToSum: valueToSum)
   }

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -236,6 +236,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional content type.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter itemCount: Optional count of items.
    - parameter paymentInfoAvailable: Optional boolean value that indicatest whether payment info is available.
    - parameter currency: Optional string representation of currency.
@@ -246,6 +247,7 @@ public extension AppEvent {
    */
   static func initiatedCheckout<T: UnsignedInteger>(contentType: String? = nil,
                                                     contentId: String? = nil,
+                                                    contentData: String? = nil,
                                                     itemCount: T? = nil,
                                                     paymentInfoAvailable: Bool? = nil,
                                                     currency: String? = nil,
@@ -254,6 +256,7 @@ public extension AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     itemCount.onSome { parameters[.itemCount] = NSNumber(value: UInt64($0)) }
     paymentInfoAvailable.onSome {
       parameters[.paymentInfoAvailable] = $0 ? FBSDKAppEventParameterValueYes : FBSDKAppEventParameterValueNo

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -62,6 +62,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional content type.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter currency: Optional string representation of currency.
    - parameter valueToSum: Optional value to sum.
    - parameter extraParameters: Optional dictionary of extra parameters.
@@ -70,12 +71,14 @@ public extension AppEvent {
    */
   static func viewedContent(contentType: String? = nil,
                             contentId: String? = nil,
+                            contentData: String? = nil,
                             currency: String? = nil,
                             valueToSum: Double? = nil,
                             extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     currency.onSome { parameters[.currency] = $0 }
     return AppEvent(name: .viewedContent, parameters: parameters, valueToSum: valueToSum)
   }

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -87,6 +87,8 @@ public extension AppEvent {
    Create an event that indicatest that the user has performed a search within the app.
 
    - parameter contentId: Optional content identifer.
+   - parameter contentData: Optional content data.
+   - parameter contentType: Optional type of the content.
    - parameter searchedString: Optional searched string.
    - parameter successful: Optional boolean value that indicatest whether the operation was succesful.
    - parameter valueToSum: Optional value to sum.
@@ -95,12 +97,16 @@ public extension AppEvent {
    - returns: An app event that can be logged via `AppEventsLogger`.
    */
   static func searched(contentId: String? = nil,
+                       contentData: String? = nil,
+                       contentType: String? = nil,
                        searchedString: String? = nil,
                        successful: Bool? = nil,
                        valueToSum: Double? = nil,
                        extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
+    contentType.onSome { parameters[.contentType] = $0 }
     searchedString.onSome { parameters[.searchedString] = $0 }
     successful.onSome { parameters[.successful] = $0 ? FBSDKAppEventParameterValueYes : FBSDKAppEventParameterValueNo }
     return AppEvent(name: .searched, parameters: parameters, valueToSum: valueToSum)

--- a/Sources/Core/AppEvents/AppEvent.Builtin.swift
+++ b/Sources/Core/AppEvents/AppEvent.Builtin.swift
@@ -167,6 +167,7 @@ public extension AppEvent {
 
    - parameter contentType: Optional content type.
    - parameter contentId: Optional content identifier.
+   - parameter contentData: Optional content data.
    - parameter currency: Optional string representation of currency.
    - parameter valueToSum: Optional value to sum.
    - parameter extraParameters: Optional dictionary of extra parameters.
@@ -175,12 +176,14 @@ public extension AppEvent {
    */
   static func addedToCart(contentType: String? = nil,
                           contentId: String? = nil,
+                          contentData: String? = nil,
                           currency: String? = nil,
                           valueToSum: Double? = nil,
                           extraParameters: ParametersDictionary = [:]) -> AppEvent {
     var parameters = extraParameters
     contentType.onSome { parameters[.contentType] = $0 }
     contentId.onSome { parameters[.contentId] = $0 }
+    contentData.onSome { parameters[.content] = $0 }
     currency.onSome { parameters[.currency] = $0 }
     return AppEvent(name: .addedToCart, parameters: parameters, valueToSum: valueToSum)
   }

--- a/Sources/Core/AppEvents/AppEventParameterName.swift
+++ b/Sources/Core/AppEvents/AppEventParameterName.swift
@@ -22,6 +22,8 @@ import FBSDKCoreKit.FBSDKAppEvents
  Represents a parameter name of the Facebook Analytics application event.
  */
 public enum AppEventParameterName: Hashable, RawRepresentable, ExpressibleByStringLiteral, CustomStringConvertible {
+  /// Data for the one or more pieces of content being logged about.
+  case content
   /// Identifier for the specific piece of content.
   case contentId
   /// Type of the content, e.g. "music"/"photo"/"video".
@@ -70,6 +72,7 @@ public enum AppEventParameterName: Hashable, RawRepresentable, ExpressibleByStri
   /// The corresponding `String` value.
   public var rawValue: String {
     switch self {
+    case .content: return FBSDKAppEventParameterNameContent
     case .contentId: return FBSDKAppEventParameterNameContentID
     case .contentType: return FBSDKAppEventParameterNameContentType
     case .currency: return FBSDKAppEventParameterNameCurrency


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fixing the following AppEvent creator functions to match the [
https://developers.facebook.com/docs/app-events/getting-started-app-events-ios#event-names](documentation)

- ViewedContent
- Searched
- Rated
- AddedToCart
- AddedToWishList
- InitiatedCheckout
- SpentCredits