### PR TITLE
Update to Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
     - master
 language: objective-c
 os: osx
-osx_image: xcode9.4
+osx_image: xcode10
 cache:
   - cocoapods
 env:

--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -102,6 +102,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		63288140214A2A8300456FF2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81AB8A0C1D36D41700066F63 /* FBSDKLoginKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0B9DBF2C207C05CD00662776;
+			remoteInfo = FBSDKLoginKit_TV;
+		};
+		63288142214A2A8300456FF2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81AB8A0C1D36D41700066F63 /* FBSDKLoginKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0B9DBF52207C07C600662776;
+			remoteInfo = "FBSDKLoginKit_TV-Dynamic";
+		};
 		811C5E471CFFD4C800E4A925 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8115C0CF1CFE540D001FF33B /* Project object */;
@@ -709,6 +723,8 @@
 				81AB8A491D36D41700066F63 /* FBSDKLoginKit.framework */,
 				81AB8A4B1D36D41700066F63 /* FBSDKLoginKit.framework */,
 				81AB8A4D1D36D41700066F63 /* FBSDKLoginKitTests.xctest */,
+				63288141214A2A8300456FF2 /* FBSDKLoginKit.framework */,
+				63288143214A2A8300456FF2 /* FBSDKLoginKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1087,6 +1103,20 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		63288141214A2A8300456FF2 /* FBSDKLoginKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = FBSDKLoginKit.framework;
+			remoteRef = 63288140214A2A8300456FF2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		63288143214A2A8300456FF2 /* FBSDKLoginKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = FBSDKLoginKit.framework;
+			remoteRef = 63288142214A2A8300456FF2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		81AB8A3B1D36D41700066F63 /* FBSDKCoreKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -1514,6 +1544,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81654DC41D356E9A006401F1 /* FacebookCore.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1521,6 +1552,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81654DC41D356E9A006401F1 /* FacebookCore.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Sources/Core/Common/SDKApplicationDelegate.swift
+++ b/Sources/Core/Common/SDKApplicationDelegate.swift
@@ -49,7 +49,7 @@ public final class SDKApplicationDelegate {
   @discardableResult
   public func
     application(_ application: UIApplication,
-                didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
+                didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     return delegate?.application(application, didFinishLaunchingWithOptions: launchOptions) ?? false
   }
 
@@ -93,7 +93,7 @@ public final class SDKApplicationDelegate {
   @discardableResult
   public func application(_ app: UIApplication,
                           open url: URL,
-                          options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
+                          options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     return delegate?.application(app,
                                  open: url,
                                  sourceApplication: options[.sourceApplication] as? String,


### PR DESCRIPTION
Swift 4.2 moves to split out some of the ApplicationDelegate keys to be named better, this implements that. It solves build errors when using the Xcode 10 GM build.

Fixes #262

# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request
