### PR TITLE
Fix #264 FBSDKSharePhoto property setter error

### DIFF
--- a/Sources/Share/Content/Photo/Photo.swift
+++ b/Sources/Share/Content/Photo/Photo.swift
@@ -64,8 +64,11 @@ public struct Photo: Equatable {
   // MARK: Internal
   internal var sdkPhotoRepresentation: FBSDKSharePhoto {
     let photo = FBSDKSharePhoto()
-    photo.image = image
-    photo.imageURL = url
+    if let image = image {
+        photo.image = image
+    } else if let imageURL = url {
+        photo.imageURL = imageURL
+    }
     photo.isUserGenerated = isUserGenerated
     photo.caption = caption
 


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request

Fix #264 .