### PR TITLE
Support sending OpenGraphShareContent with ShareDialog and fix reserved issue

### DIFF
--- a/Sources/Share/Content/OpenGraph/OpenGraphPropertyName.swift
+++ b/Sources/Share/Content/OpenGraph/OpenGraphPropertyName.swift
@@ -40,9 +40,7 @@ public struct OpenGraphPropertyName: Hashable, RawRepresentable, ExpressibleBySt
     }
 
     self.namespace = String(components[0])
-
-    let subcharacters = components[1 ... components.count]
-    self.name = subcharacters.reduce("") { $0 + ":" + String($1) }
+    self.name = String(components[1])
   }
 
   /**

--- a/Sources/Share/Content/OpenGraph/OpenGraphShareContent.swift
+++ b/Sources/Share/Content/OpenGraph/OpenGraphShareContent.swift
@@ -22,7 +22,7 @@ import Foundation
 /**
  A model for Open Graph content to be shared.
  */
-public struct OpenGraphShareContent: Equatable, SDKBridgedContent {
+public struct OpenGraphShareContent: Equatable, SDKBridgedContent, ContentProtocol {
   public typealias Result = PostSharingResult
 
   /// The Open Graph action to be shared.


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request

- Fixed the property name that was causing the "reserved" issue.
- Added ContentProtocol in order to user OpenGraphShareContent as content for ShareDialog