### PR TITLE
handle sdkResult.token == nil

### DIFF
--- a/Sources/Login/LoginResult.swift
+++ b/Sources/Login/LoginResult.swift
@@ -42,18 +42,20 @@ public enum LoginResult {
       self = .failed(error)
       return
     }
-    if sdkResult.isCancelled || sdkResult.token == nil {
+    guard !sdkResult.isCancelled, let token = sdkResult.token else {
       self = .cancelled
-    } else {
-      let grantedPermissions = (sdkResult.grantedPermissions?.compactMap { $0 as? String }
-        .map { Permission(name: $0) })
-        .map(Set.init)
-      let declinedPermissions = (sdkResult.declinedPermissions?.compactMap { $0 as? String }
-        .map { Permission(name: $0) })
-        .map(Set.init)
-      self = .success(grantedPermissions: grantedPermissions ?? [],
-                      declinedPermissions: declinedPermissions ?? [],
-                      token: AccessToken(sdkAccessToken: sdkResult.token))
+      return
+    }
+
+    let grantedPermissions = (sdkResult.grantedPermissions?.compactMap { $0 as? String }
+      .map { Permission(name: $0) })
+      .map(Set.init)
+    let declinedPermissions = (sdkResult.declinedPermissions?.compactMap { $0 as? String }
+      .map { Permission(name: $0) })
+      .map(Set.init)
+    self = .success(grantedPermissions: grantedPermissions ?? [],
+                    declinedPermissions: declinedPermissions ?? [],
+                    token: AccessToken(sdkAccessToken: token))
 
     }
   }

--- a/Sources/Login/LoginResult.swift
+++ b/Sources/Login/LoginResult.swift
@@ -42,7 +42,7 @@ public enum LoginResult {
       self = .failed(error)
       return
     }
-    if sdkResult.isCancelled {
+    if sdkResult.isCancelled || sdkResult.token == nil {
       self = .cancelled
     } else {
       let grantedPermissions = (sdkResult.grantedPermissions?.compactMap { $0 as? String }

--- a/Sources/Login/LoginResult.swift
+++ b/Sources/Login/LoginResult.swift
@@ -42,6 +42,7 @@ public enum LoginResult {
       self = .failed(error)
       return
     }
+
     guard !sdkResult.isCancelled, let token = sdkResult.token else {
       self = .cancelled
       return

--- a/Sources/Login/LoginResult.swift
+++ b/Sources/Login/LoginResult.swift
@@ -56,7 +56,5 @@ public enum LoginResult {
     self = .success(grantedPermissions: grantedPermissions ?? [],
                     declinedPermissions: declinedPermissions ?? [],
                     token: AccessToken(sdkAccessToken: token))
-
-    }
   }
 }


### PR DESCRIPTION
When a user declines a publish permission with the "NOT NOW" button, `init` of the `LoginResult` fails with fatal error because of `sdkResult.token` is `nil` 
![screen shot 2018-10-15 at 17 19 47](https://user-images.githubusercontent.com/4746211/46965504-bfc6cb80-d0b3-11e8-8072-4c24ccf8a9b2.png)
